### PR TITLE
Fixed error when there are empty fields in csv

### DIFF
--- a/libs/ParseSettings.py
+++ b/libs/ParseSettings.py
@@ -6,10 +6,10 @@ logger = logging.getLogger(__name__)
 ############ Parse settings from config
 def parse_settings(config:list) -> dict:
     assert_min_length(config)
-    assert_command(config[0])
-    assert_empty(config[1])
+    assert_command(list(filter(None, config[0])))
+    assert_empty(list(filter(None, config[1])))
     settings = {}
-    settings["command"] = config[0][0] # First line, first item
+    settings["command"] = list(filter(None, config[0]))[0] # First line, first item
     logger.info(f"Parsed command '{settings['command']}'")
     params = parse_command_into_params(settings["command"])
     logger.info(f"Parsed parameter names {params}")


### PR DESCRIPTION
Cause of error came from line 1, and 2 of the csv
Use built-in filter method to remove empty strings generated by parsing of csv
As filter generates an object it needs to be cast into a list again